### PR TITLE
fix: added root type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,7 @@ export interface CustomElementPropertyTree {
 
 export type CustomElementOptions<T> = {
   renderer?: (what: T, where: Element) => void
+  root?: "standard" | "shadow" | "shadow:closed"
   render: () => T
   computed?: CustomElementComputedTree
   props?: CustomElementPropertyTree


### PR DESCRIPTION
Noticed in a TypeScript project that I couldn't pass a string as `root` parameter value with `createComponent` so I added the needed type into `CustomElementOptions`, based on what I could find in `custom-element.mjs`.

https://github.com/ficusjs/ficusjs-core/blob/b0afe866fdbdf6588884f06863ba320592e0d634/src/custom-element.mjs#L204-L215